### PR TITLE
Don't build Cairo with LZO

### DIFF
--- a/ports/cairo/disable-lzo.patch
+++ b/ports/cairo/disable-lzo.patch
@@ -1,0 +1,22 @@
+diff --git a/meson.build b/meson.build
+index 12512d115..aec6b003a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -201,7 +201,16 @@ else
+   endif
+ endif
+ 
+-lzo_dep = dependency('lzo2', required: false)
++# TSC patch: Never look for lzo (GPL-licensed), but keep lzo_dep around so
++# downstream meson.build files will still work
++#
++# From the docs at https://mesonbuild.com/Reference-manual_functions.html#dependency
++#
++# If dependency_name is '', the dependency is always not found. 
++# So with required: false, this always returns a dependency object 
++# for which the found() method returns false, and which can be passed 
++# like any other dependency to the dependencies: keyword argument of a build_target.
++lzo_dep = dependency('', required: false)
+ if lzo_dep.found()
+   conf.set('HAVE_LZO', 1)
+ endif

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_gitlab(
         disable-atomic-ops-check.patch # See https://gitlab.freedesktop.org/cairo/cairo/-/issues/554
         mingw-dllexport.patch
         fix-static-missing-lib-msimg32.patch
+        disable-lzo.patch
         ${PATCHES}
 )
 

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -10,7 +10,6 @@
     "dirent",
     "expat",
     "libpng",
-    "lzo",
     "pixman",
     "pthread",
     {

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1366,7 +1366,7 @@
     },
     "cairo": {
       "baseline": "1.17.8",
-      "port-version": 3
+      "port-version": 4
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00cb8b7ffed9ce81f8b93d62e057076430f82948",
+      "version": "1.17.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "e8fda1b05b3f6a99f08c23f8ad94ed43d4a69875",
       "version": "1.17.8",
       "port-version": 3


### PR DESCRIPTION
We don't want Cairo to be built with LZO because LZO is a GPL library.

This PR modifies the Cairo port such that:
* Cairo's meson build file won't even look for LZO
* vcpkg won't try and build LZO