### PR TITLE
osx: Set min deployment target to 11.0

### DIFF
--- a/triplets/community/arm64-osx-dynamic-release.cmake
+++ b/triplets/community/arm64-osx-dynamic-release.cmake
@@ -6,3 +6,7 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
 
 set(VCPKG_BUILD_TYPE release)
+
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)

--- a/triplets/community/arm64-osx-static-release.cmake
+++ b/triplets/community/arm64-osx-static-release.cmake
@@ -6,3 +6,7 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
 
 set(VCPKG_BUILD_TYPE release)
+
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)

--- a/triplets/community/x64-osx-dynamic-release.cmake
+++ b/triplets/community/x64-osx-dynamic-release.cmake
@@ -6,3 +6,6 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 set(VCPKG_BUILD_TYPE release)
 
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)

--- a/triplets/community/x64-osx-static-release.cmake
+++ b/triplets/community/x64-osx-static-release.cmake
@@ -6,3 +6,6 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 set(VCPKG_BUILD_TYPE release)
 
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_LINKER_FLAGS -mmacosx-version-min=11.0)


### PR DESCRIPTION
Avoid link-time warnings:

```
ld: warning: object file (somefile.o was built for newer macOS version (12.0) than being linked (11.0))
```

### Testing
With these changes, I built `openssl:arm64-osx-dynamic-release`. I then ran the following command to inspect the deployment target of the resulting dylib:

```
➜  ~/projects/vcpkg_tsc git:(osxSetMinDeploymentTargetTo11) otool -l installed/arm64-osx-dynamic-release/lib/libcrypto.dylib | grep minos -A 2 -B 2 
  cmdsize 32
 platform 1
    minos 11.0
      sdk 13.1
   ntools 1
```

Without these changes, the output is:
```
  cmdsize 32
 platform 1
    minos 13.0
      sdk 13.1
   ntools 1
```

I did the same thing for the `arm64-osx-static-release` triplet and the correct minos was shown.
